### PR TITLE
Translation related stuff

### DIFF
--- a/Languages/English/Keyed/RQ_Keys.xml
+++ b/Languages/English/Keyed/RQ_Keys.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
+
   <RQ_LoadingScreen>Setting Quest Giver...</RQ_LoadingScreen>
   <RQ_SilverAmt>{0} silver</RQ_SilverAmt>
   <RQ_CannotQuest>Cannot check for quests</RQ_CannotQuest>
@@ -9,5 +10,21 @@
   <RQ_QuestDialogTwo>{0} writes down the specifics of the quest. [PAWN_pronoun] informs {1} how to get started.</RQ_QuestDialogTwo>
   <RQ_LackFunds>Not Enough Silver</RQ_LackFunds>
   <RQ_LackFundsMessage>Your colony doesn't have enough silver.</RQ_LackFundsMessage>
+  
+  <!-- Template for translating quests: -->
+  <!-- <RimQuest_DEFNAME>Quest name</RimQuest_DEFNAME> -->
+  <!-- Where DEFNAME is a QuestScriptDef defName [RimWorld\Data\Core|Royalty\Defs\QuestScriptDefs] -->
+  <RimQuest_OpportunitySite_BanditCamp>Bandit camp</RimQuest_OpportunitySite_BanditCamp>
+  <RimQuest_OpportunitySite_DownedRefugee>Downed refugee</RimQuest_OpportunitySite_DownedRefugee>
+  <RimQuest_OpportunitySite_ItemStash>Item stash</RimQuest_OpportunitySite_ItemStash>
+  <RimQuest_OpportunitySite_PeaceTalks>Peace talks</RimQuest_OpportunitySite_PeaceTalks>
+  <RimQuest_OpportunitySite_PrisonerWillingToJoin>Prisoner willing to join</RimQuest_OpportunitySite_PrisonerWillingToJoin>
+  <RimQuest_Hospitality_Refugee>Hospitality refugee</RimQuest_Hospitality_Refugee>
+  <RimQuest_Hospitality_Animals>Hospitality animals</RimQuest_Hospitality_Animals>
+  <RimQuest_Hospitality_Joiners>Hospitality joiners</RimQuest_Hospitality_Joiners>
+  <RimQuest_Hospitality_Prisoners>Hospitality prisoners</RimQuest_Hospitality_Prisoners>
+  
+  <!-- A RimWorld of Magic -->
+  <RimQuest_TM_OpportunitySite_ArcaneBandits>Arcane bandits</RimQuest_TM_OpportunitySite_ArcaneBandits>
 
 </LanguageData>

--- a/Languages/Russian/DefInjected/JobDef/RQ_Jobs.xml
+++ b/Languages/Russian/DefInjected/JobDef/RQ_Jobs.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- checking for quests with TargetA. -->
+  <RQ_QuestWithPawn.reportString>Расспрашивает о слухах TargetA.</RQ_QuestWithPawn.reportString>
+
+</LanguageData>

--- a/Languages/Russian/Keyed/RQ_Keys.xml
+++ b/Languages/Russian/Keyed/RQ_Keys.xml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- Setting Quest Giver... -->
+  <RQ_LoadingScreen>Установка хранителя историй...</RQ_LoadingScreen>
+  
+  <!-- {0} silver -->
+  <RQ_SilverAmt>{0} серебра</RQ_SilverAmt>
+  
+  <!-- Cannot check for quests -->
+  <RQ_CannotQuest>Не может расспросить о слухах:</RQ_CannotQuest>
+  
+  <!-- Check for quests with {0} -->
+  <RQ_QuestWith>Расспросить о слухах: {0}</RQ_QuestWith>
+  
+  <!-- Quest Opportunity -->
+  <RQ_QuestOpportunity>Шанс проявить себя</RQ_QuestOpportunity>
+  
+  <!-- {0} approaches {1} and speaks for a while. While {1} has [PAWN_possessive] own business to attend to, [PAWN_pronoun] tells {0} about a few opportunities [PAWN_pronoun] has heard about while traveling through the area. [PAWN_pronoun] does not have time to attend to everything, and [PAWN_pronoun] offers to share an opportunity in exchange for some silver ({2} total).\n\nWhich one will {0} ask about? -->
+  <RQ_QuestDialog>{0} подходит к {1} и они обмениваются приветствиями.\nНе отрываясь от своих дел, {1} рассказывает {0} о нескольких историях, что [PAWN_objective] довелось услышать во время путешествия по этому району от местных жителей.\n{1} говорит, что некоторые из них оказались в беде и наверняка не останутся в долгу за оказанную им помощь, но у н[PAWN_possessive] не так много времени, чтобы успеть разобраться во всех ситуациях, поэтому [PAWN_pronoun] предлагает поделиться информацией в обмен на некоторое количество серебра - всего {2}.\n\nО чём будет спрашивать {0}?</RQ_QuestDialog>
+  
+  <!-- {0} writes down the specifics of the quest. [PAWN_pronoun] informs {1} how to get started. -->
+  <RQ_QuestDialogTwo>(*Name){0}(/Name) записывает подробности переданной информации и говорит (*Name){1}(/Name), с чего стоит начать.</RQ_QuestDialogTwo>
+  
+  <!-- Not Enough Silver -->
+  <RQ_LackFunds>Недостаточно серебра</RQ_LackFunds>
+  
+  <!-- Your colony doesn't have enough silver. -->
+  <RQ_LackFundsMessage>Ваше поселение не располагает необходимым количеством серебра.</RQ_LackFundsMessage>
+  
+  <RimQuest_OpportunitySite_BanditCamp>Лагерь бандитов</RimQuest_OpportunitySite_BanditCamp>
+  <RimQuest_OpportunitySite_DownedRefugee>Спасение беженца</RimQuest_OpportunitySite_DownedRefugee>
+  <RimQuest_OpportunitySite_ItemStash>Схрон с припасами</RimQuest_OpportunitySite_ItemStash>
+  <RimQuest_OpportunitySite_PeaceTalks>Переговоры</RimQuest_OpportunitySite_PeaceTalks>
+  <RimQuest_OpportunitySite_PrisonerWillingToJoin>Спасение пленника</RimQuest_OpportunitySite_PrisonerWillingToJoin>
+  <RimQuest_Hospitality_Refugee>Приютить странника</RimQuest_Hospitality_Refugee>
+  <RimQuest_Hospitality_Animals>Приютить животное</RimQuest_Hospitality_Animals>
+  <RimQuest_Hospitality_Joiners>Приютить союзника</RimQuest_Hospitality_Joiners>
+  <RimQuest_Hospitality_Prisoners>Разместить заключённого</RimQuest_Hospitality_Prisoners>
+  
+  <!-- A RimWorld of Magic -->
+  <RimQuest_TM_OpportunitySite_ArcaneBandits>Мистические бандиты</RimQuest_TM_OpportunitySite_ArcaneBandits>
+
+</LanguageData>

--- a/Patches/Patches.xml
+++ b/Patches/Patches.xml
@@ -4,7 +4,7 @@
   <!-- FOR MODDERS: You can add the below to your own mod to patch your own incidentDefs.  -->
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>RimQuest</li>
+      <li>RimQuest (Continued)</li>
     </mods>
     <match Class="PatchOperationAddModExtension">
       <xpath>/Defs/IncidentDef[defName="Quest_JourneyOffer"]</xpath>

--- a/Source/RimQuest/Dialog_QuestGiver.cs
+++ b/Source/RimQuest/Dialog_QuestGiver.cs
@@ -111,20 +111,29 @@ namespace RimQuest
             for (var index = 0; index < questPawn.questsAndIncidents.Count; index++)
             {
                 string defname;
+                string keyedName;
                 object questDef = null;
                 string questName = string.Empty;
                 if (questPawn.questsAndIncidents[index] is QuestScriptDef questScriptDef)
                 {
                     defname = questScriptDef.defName;
-                    if (defname.Contains("_"))
+                    keyedName = "RimQuest_" + defname;
+                    if ((!Prefs.DevMode && keyedName.Translate() == keyedName) || (Prefs.DevMode && (keyedName.Translate().ToString().Contains("RìṁQùèșṭ_"))))
                     {
-                        defname = questScriptDef.defName.Split('_')[1];
+                        if (defname.Contains("_"))
+                        {
+                            defname = questScriptDef.defName.Split('_')[1];
+                        }
+                        if (questScriptDef.defName.Contains("Hospitality"))
+                        {
+                            defname = questScriptDef.defName.Replace("_", " ");
+                        }
+                        questName = Regex.Replace(defname, "(\\B[A-Z])", " $1");
                     }
-                    if (questScriptDef.defName.Contains("Hospitality"))
+                    else
                     {
-                        defname = questScriptDef.defName.Replace("_", " ");
+                        questName = keyedName.Translate();
                     }
-                    questName = Regex.Replace(defname, "(\\B[A-Z])", " $1");
                     questDef = questScriptDef;
                 }
                 if (questPawn.questsAndIncidents[index] is IncidentDef incidentDef)


### PR DESCRIPTION
Edited patches.xml: "RimQuest" -> "RimQuest (Continued)"
Added Russian translation files
Added an ability to translate quest names via keyed strings [RimQuest\Languages\English|YourLanguage\Keyed]
Template is as follows:
<RimQuest_DEFNAME>Quest name</RimQuest_DEFNAME>
Where DEFNAME is a QuestScriptDef defName [\Defs\QuestScriptDefs]
Example:
<RimQuest_OpportunitySite_BanditCamp>Bandit camp</RimQuest_OpportunitySite_BanditCamp>


