### PR TITLE
1.3 Fix for change to Dialog_MessageBox

### DIFF
--- a/Source/RimQuest/Dialog_QuestGiver.cs
+++ b/Source/RimQuest/Dialog_QuestGiver.cs
@@ -221,7 +221,7 @@ namespace RimQuest
                 Close();
                 Find.WindowStack.Add(new Dialog_MessageBox(
                     "RQ_QuestDialogTwo".Translate(questPawn.pawn.LabelShort, interactor.LabelShort)
-                        .AdjustedFor(questPawn.pawn), "OK".Translate(), null, null, null, title));
+                        .AdjustedFor(questPawn.pawn), "OK".Translate(), null, null, null, title, false, null, null, WindowLayer.Dialog));
             }
             else
             {


### PR DESCRIPTION
Requires new arguments as described in assembly as "buttonADestructive, Action acceptAction, Action cancelAction, WindowLayer layer"

Causes exception failure on attempt to get a quest and window pops up empty without this change.