### PR TITLE
Support giver quests

### DIFF
--- a/Source/RimQuest/Dialog_QuestGiver.cs
+++ b/Source/RimQuest/Dialog_QuestGiver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using RimWorld;
+using RimWorld.QuestGen;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -165,8 +166,14 @@ public class Dialog_QuestGiver : Window
                     comp is StorytellerComp_OnOffCycle or StorytellerComp_RandomMain);
                 incidentParms =
                     storytellerComp.GenerateParms(IncidentCategoryDefOf.GiveQuest, incidentParms.target);
+
+                var slate = new Slate();
+
+                slate.Set("points", incidentParms.points);
+                slate.Set("discoveryMethod", "QuestDiscoveredFromTrader".Translate(questPawn.pawn.Named("TRADER"), interactor.Named("NEGOTIATOR")));
+
                 QuestUtility.SendLetterQuestAvailable(
-                    QuestUtility.GenerateQuestAndMakeAvailable(questDef, incidentParms.points));
+                    QuestUtility.GenerateQuestAndMakeAvailable(questDef, slate));
             }
 
             if (selectedQuest is IncidentDef incidentDef)


### PR DESCRIPTION
Some quests require the `discoveryMethod` variable to be set in order for their descriptions to be correctly generated, mainly the `*_Giver` quests from Odyssey. This PR add support for these quests.